### PR TITLE
BUG - Set RTD to single version

### DIFF
--- a/.github/workflows/rtd-preview.yml
+++ b/.github/workflows/rtd-preview.yml
@@ -16,3 +16,4 @@ jobs:
       - uses: readthedocs/actions/preview@v1
         with:
           project-slug: "bokeh-a11y-audit"
+          single-version: "true"


### PR DESCRIPTION
I only realised we had the RTD project as single version so the preview link was pointing at the wrong URL, this should fix the link generated.

Ref: see https://github.com/Quansight-Labs/bokeh-a11y-audit/pull/31